### PR TITLE
Replace positions Hash with plain ivars

### DIFF
--- a/examples/mcts_laziness.rb
+++ b/examples/mcts_laziness.rb
@@ -11,7 +11,7 @@ mcts = MCTS::MCTS.new
  {black: 0, white: -4}].each do |position|
   [2, 4, 8, 10, 16, 32, 64, 100].each do |playouts|
     results = Hash.new {0}
-    double_step_game = MCTS::Examples::DoubleStep.new position
+    double_step_game = MCTS::Examples::DoubleStep.new position[:black], position[:white]
     10_000.times do |i|
       root = mcts.start double_step_game, playouts
       best_move = root.best_move

--- a/lib/mcts/examples/double_step.rb
+++ b/lib/mcts/examples/double_step.rb
@@ -5,15 +5,16 @@ module MCTS
       FINAL_POSITION = 6
       MAX_STEP = 2
 
-      attr_reader :positions
+      attr_reader :black, :white
 
-      def initialize(positions = init_positions, n = 0)
-        @positions = positions
+      def initialize(black = 0, white = 0, n = 0)
+        @black = black
+        @white = white
         @move_count = n
       end
 
       def finished?
-        @positions.any? {|_color, position| position >= FINAL_POSITION }
+        @white >= FINAL_POSITION || @black >= FINAL_POSITION
       end
 
       def generate_move
@@ -22,17 +23,27 @@ module MCTS
 
       def set_move(move)
         steps = move
-        @positions[next_turn_color] += steps
+        case next_turn_color
+        when :white
+          @white += steps
+        else
+          @black += steps
+        end
         @move_count += 1
       end
 
       def dup
-        self.class.new @positions.dup, @move_count
+        self.class.new @black, @white, @move_count
       end
 
       def won?(color)
         fail "Game not finished" unless finished?
-        @positions[color] > @positions[other_color(color)]
+        case color
+        when :black
+          @black > @white
+        else
+          @white > @black
+        end
       end
 
       def all_valid_moves
@@ -50,18 +61,6 @@ module MCTS
       private
       def next_turn_color
         @move_count.even? ? :black : :white
-      end
-
-      def init_positions
-        {black: 0, white: 0}
-      end
-
-      def other_color(color)
-        if color == :black
-          :white
-        else
-          :black
-        end
       end
     end
   end

--- a/spec/mcts/examples/double_step_spec.rb
+++ b/spec/mcts/examples/double_step_spec.rb
@@ -10,7 +10,8 @@ module MCTS::Examples
       end
 
       it "has the right position" do
-        expect(subject.positions).to eq(black: 0, white: 0)
+        expect(subject.black).to eq(0)
+        expect(subject.white).to eq(0)
       end
     end
 
@@ -30,7 +31,7 @@ module MCTS::Examples
       end
 
       it "sets the move for the starting color (black)" do
-        expect(subject.positions[:black]).to eq 2
+        expect(subject.black).to eq 2
       end
 
       it "returns the correct color for last turn" do
@@ -38,7 +39,7 @@ module MCTS::Examples
       end
 
       it "does not touch the moves of the other color" do
-        expect(subject.positions[:white]).to eq 0
+        expect(subject.white).to eq 0
       end
 
       describe "and another move" do
@@ -47,7 +48,7 @@ module MCTS::Examples
         end
 
         it "sets the move for white" do
-          expect(subject.positions[:white]).to eq 1
+          expect(subject.white).to eq 1
         end
 
         it "returns the correct color for last turn" do
@@ -55,13 +56,13 @@ module MCTS::Examples
         end
 
         it "does not touch the moves of the other color" do
-          expect(subject.positions[:black]).to eq 2
+          expect(subject.black).to eq 2
         end
 
         it "then changes back to the original color" do
           subject.set_move(1)
-          expect(subject.positions[:black]).to eq 3
-          expect(subject.positions[:white]).to eq 1
+          expect(subject.black).to eq 3
+          expect(subject.white).to eq 1
         end
       end
     end
@@ -100,14 +101,16 @@ module MCTS::Examples
         dup = subject.dup
         subject.set_move(1)
         dup.set_move(2)
-        expect(subject.positions).to eq(black: 2, white: 1)
-        expect(dup.positions).to eq(black: 2, white: 2)
+        expect(subject.black).to eq(2)
+        expect(subject.white).to eq(1)
+        expect(dup.black).to eq(2)
+        expect(dup.white).to eq(2)
       end
     end
 
     describe "introducing a handicap" do
       it "works" do
-        game = described_class.new({black: 4, white: 0})
+        game = described_class.new(4, 0)
         game.set_move(2)
         expect(game).to be_finished
         expect(game).to be_won(:black)


### PR DESCRIPTION
This commit avoids allocations of Hash objects
by replacing `positions` with `black` and `white` ivars.

After this commit running `examples`mcts_laziness.rb` improved:

## Before

```
real    3m57.156s
user    3m56.980s
sys     0m0.004s
```

## After

```
real    2m57.745s
user    2m57.636s
sys     0m0.000s
```

## Memory profiling

To measure the amount of allocations I used [hotch](https://github.com/splattael/hotch)'s memory profiling in `examples/mcts_laziness.rb` for 8 playouts:

```ruby
require_relative '../lib/mcts'
require_relative '../lib/mcts/examples/double_step'

gem 'hotch', '~> 0.4.1'
require 'hotch/memory'

mcts = MCTS::MCTS.new

Hotch.memory do

[
 {black: -4, white: 0}, {black: -3, white: 0}, {black: -2, white: 0},
 {black: -1, white: 0}, {black: 0, white: 0}, {black: 0, white: -1},
 {black: 0, white: -2}, {black: 0, white: -3},
 {black: 0, white: -4}].each do |position|
  [8].each do |playouts|
    results = Hash.new {0}
    double_step_game = MCTS::Examples::DoubleStep.new position[:black], position[:white]
    10_000.times do |i|
      root = mcts.start double_step_game, playouts
      best_move = root.best_move
      results[best_move] += 1
    end
    puts "Distribution for #{playouts} playouts with a handicap of #{position[:black] - position[:white]}: #{results}"
  end
end

end
```

### Result before

Before this commit hotch showed:

```
                       filename     type   count old_count total_age min_age max_age total_memsize
   examples/mcts_laziness.rb:15   T_HASH       1         1       535     535     535             0
   examples/mcts_laziness.rb:12  T_ARRAY       1         1       535     535     535             0
mcts/examples/double_step.rb:20  T_IMEMO       1         1       535     535     535             0
   examples/mcts_laziness.rb:24   T_HASH       1         1       477     477     477             0
   examples/mcts_laziness.rb:24  T_IMEMO       1         1       477     477     477             0
   examples/mcts_laziness.rb:24   T_DATA       1         0       477     477     477             0
   examples/mcts_laziness.rb:14   T_HASH       2         2      1070     535     535             0
   examples/mcts_laziness.rb:12   T_HASH       3         3      1605     535     535             0
   examples/mcts_laziness.rb:13   T_HASH       3         3      1605     535     535             0
   examples/mcts_laziness.rb:16  T_ARRAY       9         9      2688      60     535             0
   examples/mcts_laziness.rb:17   T_HASH       9         9      2688      60     535             0
   examples/mcts_laziness.rb:18 T_OBJECT       9         9      2688      60     535             0
   examples/mcts_laziness.rb:17   T_DATA      28         0      8599      60     535             0
   examples/mcts_laziness.rb:24 T_STRING      77        24      6505       0     477          1840
                 mcts/mcts.rb:4 T_OBJECT   89997        11     94345       0     516       9341504
                mcts/root.rb:12  T_IMEMO  180000        22    187620       0     516       7186000
                mcts/node.rb:83 T_OBJECT  720000        88    752731       0     516      74734416
                mcts/node.rb:43 T_OBJECT  720000         0    719636       0       2      28747880
                mcts/node.rb:11  T_ARRAY  810000        99    847020       0     516      32337000
mcts/examples/double_step.rb:42  T_ARRAY  810000        99    846966       0     516      32337000
mcts/examples/double_step.rb:30 T_OBJECT 1440000        88   1472387       0     516      57491840
                mcts/node.rb:33  T_IMEMO 1451285         1   1450821       0     535      57947040
mcts/examples/double_step.rb:30   T_HASH 2880000        88   2911873       0     516     390948432
                          TOTAL          9101428       560   9313883    4881   11407     691072952
```

### Result after

After this commit hotch shows:

```
                       filename     type   count old_count total_age min_age max_age total_memsize
   examples/mcts_laziness.rb:15   T_HASH       1         1       360     360     360             0
   examples/mcts_laziness.rb:12  T_ARRAY       1         1       360     360     360             0
mcts/examples/double_step.rb:21  T_IMEMO       1         1       360     360     360             0
   examples/mcts_laziness.rb:24   T_HASH       1         1       320     320     320             0
   examples/mcts_laziness.rb:24  T_IMEMO       1         1       320     320     320             0
   examples/mcts_laziness.rb:24   T_DATA       1         0       320     320     320             0
   examples/mcts_laziness.rb:14   T_HASH       2         2       720     360     360             0
   examples/mcts_laziness.rb:12   T_HASH       3         3      1080     360     360             0
   examples/mcts_laziness.rb:13   T_HASH       3         3      1080     360     360             0
   examples/mcts_laziness.rb:16  T_ARRAY       9         9      1802      40     360             0
   examples/mcts_laziness.rb:17   T_HASH       9         9      1802      40     360             0
   examples/mcts_laziness.rb:18 T_OBJECT       9         9      1802      40     360             0
   examples/mcts_laziness.rb:17   T_DATA      28         0      5766      40     360             0
   examples/mcts_laziness.rb:24 T_STRING      77        24      4372       0     320          1840
                 mcts/mcts.rb:4 T_OBJECT   90000         0     90885       0       3       9334120
                mcts/root.rb:12  T_IMEMO  180000         0    180867       0       3       7180080
                mcts/node.rb:83 T_OBJECT  720000         0    725737       0       3      74673472
                mcts/node.rb:43 T_OBJECT  720000         0    719675       0       2      28721200
                mcts/node.rb:11  T_ARRAY  810000         0    816591       0       3      32310600
mcts/examples/double_step.rb:53  T_ARRAY  810000         0    816533       0       3      32310640
mcts/examples/double_step.rb:36 T_OBJECT 1440000         0   1445467       0       3      57441800
                mcts/node.rb:33  T_IMEMO 1451439         1   1451479       0     360      57899920
                          TOTAL          6221585        65   6267698    3280    5260     299873672
```

*Note*: Disabling the GC would give more precise and stable numbers of allocations.


Edit: A couple of edits