### PR TITLE
Prefer `Array#sample` over `Kernel#rand` for move generation

### DIFF
--- a/lib/mcts/examples/double_step.rb
+++ b/lib/mcts/examples/double_step.rb
@@ -3,7 +3,7 @@ module MCTS
     class DoubleStep
 
       FINAL_POSITION = 6
-      MAX_STEP = 2
+      STEPS = [1, 2]
 
       attr_reader :black, :white
 
@@ -18,7 +18,7 @@ module MCTS
       end
 
       def generate_move
-        rand(MAX_STEP) + 1
+        STEPS.sample
       end
 
       def set_move(move)


### PR DESCRIPTION
```ruby
require "benchmark/ips"

steps = (1..2).to_a

Benchmark.ips do |x|
  x.report "rand" do
    rand(2) + 1
  end

  x.report "sample" do
    steps.sample
  end
end
```


```
$ ruby foo.rb 
Warming up --------------------------------------
                rand   264.692k i/100ms
              sample   328.867k i/100ms
Calculating -------------------------------------
                rand      5.799M (± 7.9%) i/s -     28.851M in   5.018178s
              sample      9.404M (± 8.5%) i/s -     46.699M in   5.021198s
```